### PR TITLE
Fix/pool retry on error

### DIFF
--- a/src/pool.tsx
+++ b/src/pool.tsx
@@ -10,7 +10,7 @@ import { Nullable } from './types'
 import { Deferred, delayedPromise } from './util'
 
 const RETRY_INTERVAL = 1000 * 5 // 5 seconds
-const RETRY_COUNT_DEFAULT_VALUE = 5
+const RETRY_COUNT_DEFAULT_VALUE = 15
 let initRetryCount = RETRY_COUNT_DEFAULT_VALUE
 
 interface IPoolContext {
@@ -116,7 +116,10 @@ export function UsePoolProvider({
         setError((err && err.message) || err?.toString())
 
         if (retryOnError && initRetryCount >= 0) {
-          return delayedPromise(RETRY_INTERVAL, init({ retryOnError: true }))
+          return delayedPromise(
+            () => init({ retryOnError: true }),
+            RETRY_INTERVAL
+          )
         }
 
         // Notify promise waiters that the process failed

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,3 +22,10 @@ export class Deferred<T> {
   resolve: (value: T | PromiseLike<T>) => void
   reject: (error: Error) => void
 }
+
+/** Waits `delay` milliseconds and executes the given `fn` returning its promise */
+export function delayedPromise<T>(delay: number, fn: () => T) {
+  return new Promise(resolve => {
+    setTimeout(resolve, delay)
+  }).then(() => fn())
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,8 +24,8 @@ export class Deferred<T> {
 }
 
 /** Waits `delay` milliseconds and executes the given `fn` returning its promise */
-export function delayedPromise<T>(delay: number, fn: () => T) {
+export function delayedPromise<T>(fn: () => Promise<T>, delayMs: number) {
   return new Promise(resolve => {
-    setTimeout(resolve, delay)
+    setTimeout(resolve, delayMs)
   }).then(() => fn())
 }


### PR DESCRIPTION
This is a follow-up of PR #8 (should be merged first)

- When UI clients import the `usePool` hook, initialization may fail
- Clients expect a working `pool` client, as React components are not meant to be monitoring errors as side effects and retry the `init` imperatively
